### PR TITLE
change the ilo Github link part to just be Github

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -38,9 +38,9 @@
 			<Link href="https://github.com/cubedhuang/">ilo Tani</Link> li pali e
 			ni. jan
 			<Link href="https://github.com/woflydev/">woflydev</Link> li ilo PWA
-			e lipu ni. sina wile ante pona e lipu ni la, o kepeken
+			e lipu ni. sina wile ante pona e lipu ni la, o kepeken ilo
 			<Link href="https://github.com/cubedhuang/sona-nimi"
-				>ilo GitHub</Link
+				>GitHub</Link
 			>!
 		</p>
 


### PR DESCRIPTION
i apologize for how unreadable that title is. all this pr does is it makes the headnoun on *ilo* Github not a link. if anybody can figure out a way to explain this better, please do tell me. i am doing this just for a little more consistency on whether or not headnouns are clickable in the about page, since it seems slightly random to me.