### PR TITLE
suno en pimeja li ken kule

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -33,10 +33,25 @@
 		<script>
 			// @ts-check
 			{
+				const isDark = window.matchMedia(
+					'(prefers-color-scheme: dark)'
+				).matches;
+
 				/** @type {string | null} */
 				let themeValue;
 				try {
-					let value = localStorage.getItem('nimi.li:theme');
+					/** @type {string | null} */
+					let value;
+					let systemTheme = localStorage.getItem('nimi.li:system-theme');
+					if (systemTheme == 'true') {
+						if (isDark) {
+							value = localStorage.getItem('nimi.li:dark-theme');
+						} else {
+							value = localStorage.getItem('nimi.li:light-theme');
+						}
+					} else {
+						value = localStorage.getItem('nimi.li:base-theme');
+					}
 					themeValue = value ? JSON.parse(value) : null;
 				} catch {
 					themeValue = null;
@@ -45,10 +60,6 @@
 				if (themeValue) {
 					document.documentElement.classList.add(themeValue);
 				} else {
-					const isDark = window.matchMedia(
-						'(prefers-color-scheme: dark)'
-					).matches;
-
 					document.documentElement.classList.toggle('dark', isDark);
 				}
 

--- a/src/routes/SystemOption.svelte
+++ b/src/routes/SystemOption.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { systemTheme } from '$lib/stores';
+
+	interface Props {
+		class?: string | undefined;
+	}
+
+	const { class: className = undefined }: Props = $props();
+
+	const selected = $derived($systemTheme);
+</script>
+
+<button
+	class="interactable grid size-12 place-items-center text-lg transition-colors {className}
+		{selected
+		? 'ring-2 ring-secondary-foreground ring-offset-2 ring-offset-card'
+		: ''}"
+	onclick={e => {
+		e.stopPropagation();
+		$systemTheme = !$systemTheme;
+	}}
+	ontouchstart={e => e.stopPropagation()}
+	role="option"
+	aria-selected={selected}
+	aria-label={"toggle system theme"}
+>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		fill="none"
+		viewBox="0 0 24 24"
+		stroke-width="1.5"
+		stroke="currentColor"
+		class="size-6"
+	>
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25"
+		/>
+	</svg>
+</button>

--- a/src/routes/ThemeOption.svelte
+++ b/src/routes/ThemeOption.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { theme, type Theme } from '$lib/stores';
+	import { baseTheme, lightTheme, darkTheme, systemTheme, type Theme, isDarkTheme } from '$lib/stores';
 
 	interface Props {
 		value: Theme;
@@ -7,8 +7,11 @@
 	}
 
 	const { value, class: className = undefined }: Props = $props();
+	
+	const theme = isDarkTheme(value) ? darkTheme : lightTheme;
 
-	const selected = $derived(value === $theme);
+	const selected = $derived($systemTheme ? (value === $theme) : (value === $baseTheme));
+	console.log(value, isDarkTheme(value));
 </script>
 
 <button
@@ -18,29 +21,17 @@
 		: ''}"
 	onclick={e => {
 		e.stopPropagation();
-		$theme = value;
+
+		if ($systemTheme) {
+			$theme = value;
+		} else {
+			$baseTheme = value;
+		}
 	}}
 	ontouchstart={e => e.stopPropagation()}
 	role="option"
 	aria-selected={selected}
 	aria-label={value}
 >
-	{#if value === 'system'}
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			fill="none"
-			viewBox="0 0 24 24"
-			stroke-width="1.5"
-			stroke="currentColor"
-			class="size-6"
-		>
-			<path
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25"
-			/>
-		</svg>
-	{:else}
-		<span aria-hidden="true"> Aa </span>
-	{/if}
+	<span aria-hidden="true"> Aa </span>
 </button>

--- a/src/routes/ThemeSelector.svelte
+++ b/src/routes/ThemeSelector.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { flyAndScale } from '$lib/transitions';
 	import FontOption from './FontOption.svelte';
+	import SystemOption from './SystemOption.svelte';
 	import ThemeOption from './ThemeOption.svelte';
 
 	let opened = $state(false);
@@ -47,8 +48,7 @@
 			class="absolute right-0 top-full z-50 mt-2 w-max rounded-lg border bg-card p-4 shadow-md"
 		>
 			<div class="flex justify-center">
-				<ThemeOption
-					value="system"
+				<SystemOption
 					class="bg-white text-gray-950 dark:bg-black dark:text-gray-50"
 				/>
 			</div>


### PR DESCRIPTION
This turns the "system theme" button into a separate toggle, allowing a user to pick a specific light and dark theme that will be automatically switched between, rather than being stuck with the default light and dark themes. 

I admit that the logic is slightly overcomplicated, but I think this behavior makes the most sense to me from a ux perspective. I'd definitely be open to cutting it back if needed, though.

One thing not currently included in this pull request is a way to migrate the user's previous preference (since it no longer uses the plain `nimi.li:theme` key). I can also add that if needed.

Screenshot:
![image](https://github.com/user-attachments/assets/a3f70d92-34de-41e1-93b1-69bc3d2f321d)
