### PR TITLE
feat: use 2025 survey data

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -107,7 +107,7 @@ export function getShortWordEtymologies(
 }
 
 export function getWordRecognition(word: LocalizedWord) {
-	return word.usage['2024-09'] ?? -1;
+	return word.usage['2025-09'] ?? -1;
 }
 
 export function getWordDisplayRecognition(word: LocalizedWord) {


### PR DESCRIPTION
While this data was already available and is accessible by clicking the (i) in word pages, the main dictionary page still uses 2024 survey data.

I've not self-hosted this to check it works, but this seems about right.