### PR TITLE
don't capitalise search terms

### DIFF
--- a/src/lib/components/Search.svelte
+++ b/src/lib/components/Search.svelte
@@ -66,6 +66,7 @@
 
 		<input
 			type="search"
+			autocapitalize="off"
 			{placeholder}
 			bind:value
 			bind:this={searchBar}


### PR DESCRIPTION
On mobile, search is prompted to start with a capital, this should prevent that happening.